### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,10 +12,10 @@
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-init    KEYWORD2
-getTemperature  KEYWORD2
-getPressure KEYWORD2
-calcAltitude    KEYWORD2
+init	KEYWORD2
+getTemperature	KEYWORD2
+getPressure	KEYWORD2
+calcAltitude	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords